### PR TITLE
fix: localStorage for persistent account

### DIFF
--- a/client/src/features/auth/loginform.tsx
+++ b/client/src/features/auth/loginform.tsx
@@ -37,7 +37,7 @@ export function LoginForm({
   const navigate = useNavigate();
   const onSubmit = (data: LoginSchema) => {
     if (data.email === 'admin@lift.com' && data.password === 'admin123') {
-      sessionStorage.setItem(
+      localStorage.setItem(
         'user',
         JSON.stringify({ ...data, name: 'AdminLift' }),
       );

--- a/client/src/features/auth/useUser.ts
+++ b/client/src/features/auth/useUser.ts
@@ -3,7 +3,7 @@ type User = {
   email: string;
 };
 export default function useUser(): User {
-  const userData = sessionStorage.getItem('user');
+  const userData = localStorage.getItem('user');
   const currentUser = userData ? JSON.parse(userData) : null;
   return currentUser;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sign-in state now persists across browser restarts. Login details are stored in your device’s local storage rather than session-based storage.
  * Admin login and user detection use the same persistent storage, so you won’t need to reauthenticate when opening new tabs or returning later.
  * Your session remains active until you sign out or clear site data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->